### PR TITLE
feat: Add categories to investments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .DS_Store
 coverage/
 .next/
+tsconfig.tsbuildinfo

--- a/app/InvestmentsTable.tsx
+++ b/app/InvestmentsTable.tsx
@@ -3,19 +3,14 @@
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import type { Category, Investment, Label } from '../lib/types';
+import type { Investment, Label } from '../lib/types';
 
 interface InvestmentsTableProps {
   investments: Investment[];
-  categories: Category[];
   labels: Label[];
 }
 
-export function InvestmentsTable({
-  investments,
-  categories,
-  labels: labelsData,
-}: InvestmentsTableProps) {
+export function InvestmentsTable({ investments, labels: labelsData }: InvestmentsTableProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +63,6 @@ export function InvestmentsTable({
           </thead>
           <tbody className="text-gray-700">
             {investments.map((investment) => {
-              const category = categories.find((cat) => cat.id === investment.categoryId);
               const labels = investment.labelIds
                 .map((labelId) => labelsData.find((lbl) => lbl.id === labelId))
                 .filter((l): l is Label => l !== undefined);
@@ -78,17 +72,7 @@ export function InvestmentsTable({
               return (
                 <tr key={investment.id} className="border-b border-gray-200 hover:bg-gray-100">
                   <td className="py-3 px-4">{investment.instrument}</td>
-                  <td className="py-3 px-4">
-                    {category && (
-                      <span className="flex items-center">
-                        <span
-                          className="inline-block w-3 h-3 rounded-full mr-2"
-                          style={{ backgroundColor: category.color }}
-                        ></span>
-                        {category.name}
-                      </span>
-                    )}
-                  </td>
+                  <td className="py-3 px-4">{investment.category}</td>
                   <td className="py-3 px-4">{investment.amount}</td>
                   <td className="py-3 px-4">{investment.price.toFixed(2)}</td>
                   <td className="py-3 px-4">{investment.purchaseDate}</td>

--- a/app/add/AddInvestmentForm.tsx
+++ b/app/add/AddInvestmentForm.tsx
@@ -3,37 +3,40 @@
 import { useState, useTransition, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import type { Category, Label } from '../../lib/types';
+import { CATEGORIES, type Label } from '../../lib/types';
 
 interface AddInvestmentFormProps {
-  categories: Category[];
   labels: Label[];
   defaultDate: string;
 }
 
-export function AddInvestmentForm({
-  categories,
-  labels,
-  defaultDate,
-}: AddInvestmentFormProps) {
+export function AddInvestmentForm({ labels, defaultDate }: AddInvestmentFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [categoryError, setCategoryError] = useState<string | null>(null);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setCategoryError(null);
 
     const formData = new FormData(event.currentTarget);
     const labelIds = formData.getAll('labelIds').map(String);
     const notes = String(formData.get('notes') ?? '').trim();
+    const category = String(formData.get('category') ?? '');
+
+    if (!category) {
+      setCategoryError('Category is required');
+      return;
+    }
 
     const payload = {
       instrument: String(formData.get('instrument') ?? '').trim(),
       amount: Number(formData.get('amount')),
       price: Number(formData.get('price')),
       purchaseDate: String(formData.get('purchaseDate') ?? ''),
-      categoryId: String(formData.get('categoryId') ?? ''),
+      category,
       labelIds,
       ...(notes && { notes }),
     };
@@ -122,25 +125,30 @@ export function AddInvestmentForm({
       </div>
 
       <div>
-        <label htmlFor="categoryId" className="block text-sm font-medium mb-1">
+        <label htmlFor="category" className="block text-sm font-medium mb-1">
           Category
         </label>
         <select
-          id="categoryId"
-          name="categoryId"
+          id="category"
+          name="category"
           required
           defaultValue=""
           className="w-full border border-gray-300 rounded px-3 py-2"
         >
           <option value="" disabled>
-            Select a category
+            -- Select a category --
           </option>
-          {categories.map((category) => (
-            <option key={category.id} value={category.id}>
-              ● {category.name}
+          {CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {category}
             </option>
           ))}
         </select>
+        {categoryError && (
+          <p role="alert" className="text-sm text-red-700 mt-1">
+            {categoryError}
+          </p>
+        )}
       </div>
 
       <fieldset>

--- a/app/add/page.test.tsx
+++ b/app/add/page.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import AddPage from './page';
 import { storage } from '../../lib/storage';
+import { CATEGORIES } from '../../lib/types';
 
 vi.mock('../../lib/storage', () => ({
   storage: {
@@ -10,10 +11,13 @@ vi.mock('../../lib/storage', () => ({
   },
 }));
 
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
-    push: vi.fn(),
-    refresh: vi.fn(),
+    push: pushMock,
+    refresh: refreshMock,
   }),
 }));
 
@@ -22,17 +26,19 @@ const today = new Date().toISOString().slice(0, 10);
 describe('AddPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    pushMock.mockClear();
+    refreshMock.mockClear();
     (storage.readAll as unknown as vi.Mock).mockResolvedValue({
       investments: [],
-      categories: [
-        { id: 'cat-stocks', name: 'Stocks', color: '#3b82f6' },
-        { id: 'cat-crypto', name: 'Crypto', color: '#f59e0b' },
-      ],
       labels: [
         { id: 'lbl-longterm', name: 'long-term', color: '#059669' },
         { id: 'lbl-highrisk', name: 'high-risk', color: '#dc2626' },
       ],
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('renders all form inputs with proper labels', async () => {
@@ -70,12 +76,27 @@ describe('AddPage', () => {
     expect(notes.tagName).toBe('TEXTAREA');
   });
 
-  it('lists existing categories as options', async () => {
+  it('renders all six predefined categories as options', async () => {
     const Resolved = await AddPage();
     render(Resolved);
 
-    expect(screen.getByRole('option', { name: /Stocks/i })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Crypto/i })).toBeInTheDocument();
+    for (const category of CATEGORIES) {
+      expect(screen.getByRole('option', { name: category })).toBeInTheDocument();
+    }
+  });
+
+  it('shows a disabled placeholder selected by default', async () => {
+    const Resolved = await AddPage();
+    render(Resolved);
+
+    const placeholder = screen.getByRole('option', {
+      name: /select a category/i,
+    }) as HTMLOptionElement;
+    expect(placeholder).toBeInTheDocument();
+    expect(placeholder.disabled).toBe(true);
+
+    const category = screen.getByLabelText(/category/i) as HTMLSelectElement;
+    expect(category.value).toBe('');
   });
 
   it('lists existing labels as checkboxes', async () => {
@@ -102,5 +123,45 @@ describe('AddPage', () => {
     const cancel = screen.getByRole('link', { name: /cancel/i }) as HTMLAnchorElement;
     expect(cancel).toBeInTheDocument();
     expect(cancel.getAttribute('href')).toBe('/');
+  });
+
+  it('shows a validation error when submitted without selecting a category', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const Resolved = await AddPage();
+    render(Resolved);
+
+    fireEvent.change(screen.getByLabelText(/instrument/i), { target: { value: 'AAPL' } });
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: '150' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const error = await screen.findByRole('alert');
+    expect(error).toHaveTextContent(/category is required/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('submits a POST with the selected category in the payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const Resolved = await AddPage();
+    render(Resolved);
+
+    fireEvent.change(screen.getByLabelText(/instrument/i), { target: { value: 'AAPL' } });
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: '150' } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Crypto' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.category).toBe('Crypto');
   });
 });

--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -2,13 +2,13 @@ import { storage } from '../../lib/storage';
 import { AddInvestmentForm } from './AddInvestmentForm';
 
 export default async function AddPage() {
-  const { categories, labels } = await storage.readAll();
+  const { labels } = await storage.readAll();
   const today = new Date().toISOString().slice(0, 10);
 
   return (
     <main className="container mx-auto p-4">
       <h1 className="text-3xl font-bold mb-6">Add investment</h1>
-      <AddInvestmentForm categories={categories} labels={labels} defaultDate={today} />
+      <AddInvestmentForm labels={labels} defaultDate={today} />
     </main>
   );
 }

--- a/app/api/investments/[id]/route.test.ts
+++ b/app/api/investments/[id]/route.test.ts
@@ -75,7 +75,7 @@ describe('PUT /api/investments/[id]', () => {
     amount: 12,
     price: 155,
     purchaseDate: '2026-01-15',
-    categoryId: 'cat-stocks',
+    category: 'Stocks' as const,
     labelIds: ['lbl-longterm'],
     notes: 'Updated position',
   };
@@ -115,7 +115,7 @@ describe('PUT /api/investments/[id]', () => {
       // amount missing
       price: 150,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
     };
 
     const response = await PUT(
@@ -137,6 +137,48 @@ describe('PUT /api/investments/[id]', () => {
 
     expect(response.status).toBe(400);
     expect(storage.updateInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when category is missing', async () => {
+    const { category: _omit, ...withoutCategory } = validPayload;
+
+    const response = await PUT(
+      makePutRequest('inv-001', withoutCategory),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(storage.updateInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when category is not in CATEGORIES', async () => {
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, category: 'NotACategory' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(storage.updateInvestment).not.toHaveBeenCalled();
+  });
+
+  it('updates the category when a valid one is provided', async () => {
+    const updated: Investment = {
+      id: 'inv-001',
+      ...validPayload,
+      category: 'Crypto',
+    };
+    (storage.updateInvestment as unknown as vi.Mock).mockResolvedValue(updated);
+
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, category: 'Crypto' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(storage.updateInvestment).toHaveBeenCalledWith(
+      'inv-001',
+      expect.objectContaining({ category: 'Crypto' }),
+    );
   });
 
   it('returns 400 when the body is not valid JSON', async () => {

--- a/app/api/investments/[id]/route.ts
+++ b/app/api/investments/[id]/route.ts
@@ -47,7 +47,7 @@ export async function PUT(
     amount: parsed.data.amount,
     price: parsed.data.price,
     purchaseDate: parsed.data.purchaseDate,
-    categoryId: parsed.data.categoryId,
+    category: parsed.data.category,
     labelIds: parsed.data.labelIds,
     ...(parsed.data.notes !== undefined && { notes: parsed.data.notes }),
   };

--- a/app/api/investments/route.test.ts
+++ b/app/api/investments/route.test.ts
@@ -31,7 +31,7 @@ describe('POST /api/investments', () => {
       amount: 10,
       price: 150,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
       labelIds: ['lbl-longterm'],
       notes: 'Initial position',
     };
@@ -44,7 +44,7 @@ describe('POST /api/investments', () => {
     expect(body.amount).toBe(10);
     expect(body.price).toBe(150);
     expect(body.purchaseDate).toBe('2026-01-15');
-    expect(body.categoryId).toBe('cat-stocks');
+    expect(body.category).toBe('Stocks');
     expect(body.labelIds).toEqual(['lbl-longterm']);
     expect(body.notes).toBe('Initial position');
     expect(body.id).toMatch(UUID_REGEX);
@@ -60,7 +60,7 @@ describe('POST /api/investments', () => {
       amount: 0.5,
       price: 60000,
       purchaseDate: '2026-02-01',
-      categoryId: 'cat-crypto',
+      category: 'Crypto',
       labelIds: [],
     };
 
@@ -78,7 +78,7 @@ describe('POST /api/investments', () => {
       // amount missing
       price: 150,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
     };
 
     const response = await POST(makeRequest(payload));
@@ -95,7 +95,7 @@ describe('POST /api/investments', () => {
       amount: -5,
       price: 150,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
       labelIds: [],
     };
 
@@ -113,7 +113,7 @@ describe('POST /api/investments', () => {
       amount: 5,
       price: 0,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
       labelIds: [],
     };
 
@@ -129,13 +129,48 @@ describe('POST /api/investments', () => {
       amount: 5,
       price: 100,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
       labelIds: [],
     };
 
     const response = await POST(makeRequest(payload));
 
     expect(response.status).toBe(400);
+    expect(storage.addInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when category is missing', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 5,
+      price: 100,
+      purchaseDate: '2026-01-15',
+      labelIds: [],
+    };
+
+    const response = await POST(makeRequest(payload));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
+    expect(storage.addInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when category is not in CATEGORIES', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 5,
+      price: 100,
+      purchaseDate: '2026-01-15',
+      category: 'NotARealCategory',
+      labelIds: [],
+    };
+
+    const response = await POST(makeRequest(payload));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
     expect(storage.addInvestment).not.toHaveBeenCalled();
   });
 
@@ -158,7 +193,7 @@ describe('POST /api/investments', () => {
       amount: 10,
       price: 150,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
     };
 
     const response = await POST(makeRequest(payload));

--- a/app/api/investments/route.ts
+++ b/app/api/investments/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
     amount: parsed.data.amount,
     price: parsed.data.price,
     purchaseDate: parsed.data.purchaseDate,
-    categoryId: parsed.data.categoryId,
+    category: parsed.data.category,
     labelIds: parsed.data.labelIds,
     ...(parsed.data.notes !== undefined && { notes: parsed.data.notes }),
   };

--- a/app/api/investments/schema.ts
+++ b/app/api/investments/schema.ts
@@ -1,11 +1,14 @@
 import { z } from 'zod';
+import { CATEGORIES } from '../../../lib/types';
 
 export const investmentSchema = z.object({
   instrument: z.string().trim().min(1, 'Instrument is required'),
   amount: z.number().positive('Amount must be a positive number'),
   price: z.number().positive('Price must be a positive number'),
   purchaseDate: z.string().min(1, 'Purchase date is required'),
-  categoryId: z.string().min(1, 'Category is required'),
+  category: z.enum(CATEGORIES, {
+    message: `Category must be one of: ${CATEGORIES.join(', ')}`,
+  }),
   labelIds: z.array(z.string()).default([]),
   notes: z.string().optional(),
 });

--- a/app/edit/[id]/EditInvestmentForm.test.tsx
+++ b/app/edit/[id]/EditInvestmentForm.test.tsx
@@ -14,11 +14,6 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
-const categories = [
-  { id: 'cat-stocks', name: 'Stocks', color: '#3b82f6' },
-  { id: 'cat-crypto', name: 'Crypto', color: '#f59e0b' },
-];
-
 const labels = [
   { id: 'lbl-longterm', name: 'long-term', color: '#059669' },
   { id: 'lbl-highrisk', name: 'high-risk', color: '#dc2626' },
@@ -30,7 +25,7 @@ const investment: Investment = {
   amount: 10,
   price: 150,
   purchaseDate: '2026-01-15',
-  categoryId: 'cat-stocks',
+  category: 'Stocks',
   labelIds: ['lbl-longterm'],
   notes: 'Initial position',
 };
@@ -47,19 +42,20 @@ describe('EditInvestmentForm', () => {
     vi.restoreAllMocks();
   });
 
+  it('pre-selects the investment current category', () => {
+    render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+    const category = screen.getByLabelText(/category/i) as HTMLSelectElement;
+    expect(category.value).toBe('Stocks');
+  });
+
   it('submits a PUT /api/investments/<id> request with the edited payload', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ...investment, price: 175 }), { status: 200 }),
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    render(
-      <EditInvestmentForm
-        investment={investment}
-        categories={categories}
-        labels={labels}
-      />,
-    );
+    render(<EditInvestmentForm investment={investment} labels={labels} />);
 
     const price = screen.getByLabelText(/price/i) as HTMLInputElement;
     fireEvent.change(price, { target: { value: '175' } });
@@ -86,7 +82,7 @@ describe('EditInvestmentForm', () => {
       amount: 10,
       price: 175,
       purchaseDate: '2026-01-15',
-      categoryId: 'cat-stocks',
+      category: 'Stocks',
       labelIds: ['lbl-longterm'],
       notes: 'Initial position',
     });
@@ -96,19 +92,33 @@ describe('EditInvestmentForm', () => {
     });
   });
 
+  it('sends the new category when changed and submitted', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ...investment, category: 'Crypto' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Crypto' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.category).toBe('Crypto');
+  });
+
   it('shows an inline error message when the server returns an error', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: 'something broke' }), { status: 500 }),
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    render(
-      <EditInvestmentForm
-        investment={investment}
-        categories={categories}
-        labels={labels}
-      />,
-    );
+    render(<EditInvestmentForm investment={investment} labels={labels} />);
 
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
 

--- a/app/edit/[id]/EditInvestmentForm.tsx
+++ b/app/edit/[id]/EditInvestmentForm.tsx
@@ -3,37 +3,40 @@
 import { useState, useTransition, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import type { Category, Investment, Label } from '../../../lib/types';
+import { CATEGORIES, type Investment, type Label } from '../../../lib/types';
 
 interface EditInvestmentFormProps {
   investment: Investment;
-  categories: Category[];
   labels: Label[];
 }
 
-export function EditInvestmentForm({
-  investment,
-  categories,
-  labels,
-}: EditInvestmentFormProps) {
+export function EditInvestmentForm({ investment, labels }: EditInvestmentFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [categoryError, setCategoryError] = useState<string | null>(null);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setCategoryError(null);
 
     const formData = new FormData(event.currentTarget);
     const labelIds = formData.getAll('labelIds').map(String);
     const notes = String(formData.get('notes') ?? '').trim();
+    const category = String(formData.get('category') ?? '');
+
+    if (!category) {
+      setCategoryError('Category is required');
+      return;
+    }
 
     const payload = {
       instrument: String(formData.get('instrument') ?? '').trim(),
       amount: Number(formData.get('amount')),
       price: Number(formData.get('price')),
       purchaseDate: String(formData.get('purchaseDate') ?? ''),
-      categoryId: String(formData.get('categoryId') ?? ''),
+      category,
       labelIds,
       ...(notes && { notes }),
     };
@@ -125,25 +128,30 @@ export function EditInvestmentForm({
       </div>
 
       <div>
-        <label htmlFor="categoryId" className="block text-sm font-medium mb-1">
+        <label htmlFor="category" className="block text-sm font-medium mb-1">
           Category
         </label>
         <select
-          id="categoryId"
-          name="categoryId"
+          id="category"
+          name="category"
           required
-          defaultValue={investment.categoryId}
+          defaultValue={investment.category}
           className="w-full border border-gray-300 rounded px-3 py-2"
         >
           <option value="" disabled>
-            Select a category
+            -- Select a category --
           </option>
-          {categories.map((category) => (
-            <option key={category.id} value={category.id}>
-              ● {category.name}
+          {CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {category}
             </option>
           ))}
         </select>
+        {categoryError && (
+          <p role="alert" className="text-sm text-red-700 mt-1">
+            {categoryError}
+          </p>
+        )}
       </div>
 
       <fieldset>

--- a/app/edit/[id]/page.test.tsx
+++ b/app/edit/[id]/page.test.tsx
@@ -22,7 +22,6 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
-const mockCategory = { id: 'cat-stocks', name: 'Stocks', color: '#3b82f6' };
 const mockLabel = { id: 'lbl-longterm', name: 'long-term', color: '#059669' };
 const mockInvestment = {
   id: 'inv-001',
@@ -30,7 +29,7 @@ const mockInvestment = {
   amount: 10,
   price: 150,
   purchaseDate: '2026-01-15',
-  categoryId: mockCategory.id,
+  category: 'Stocks',
   labelIds: [mockLabel.id],
   notes: 'Initial position',
 };
@@ -40,7 +39,6 @@ describe('EditPage', () => {
     vi.clearAllMocks();
     (storage.readAll as unknown as vi.Mock).mockResolvedValue({
       investments: [mockInvestment],
-      categories: [mockCategory],
       labels: [mockLabel],
     });
   });
@@ -62,7 +60,7 @@ describe('EditPage', () => {
     expect(purchaseDate.defaultValue).toBe('2026-01-15');
 
     const category = screen.getByLabelText(/category/i) as HTMLSelectElement;
-    expect(category.value).toBe('cat-stocks');
+    expect(category.value).toBe('Stocks');
 
     const longterm = screen.getByLabelText(/long-term/i) as HTMLInputElement;
     expect(longterm.defaultChecked).toBe(true);

--- a/app/edit/[id]/page.tsx
+++ b/app/edit/[id]/page.tsx
@@ -8,7 +8,7 @@ interface EditPageProps {
 
 export default async function EditPage({ params }: EditPageProps) {
   const { id } = await params;
-  const { investments, categories, labels } = await storage.readAll();
+  const { investments, labels } = await storage.readAll();
   const investment = investments.find((inv) => inv.id === id);
 
   if (!investment) {
@@ -18,11 +18,7 @@ export default async function EditPage({ params }: EditPageProps) {
   return (
     <main className="container mx-auto p-4">
       <h1 className="text-3xl font-bold mb-6">Edit investment</h1>
-      <EditInvestmentForm
-        investment={investment}
-        categories={categories}
-        labels={labels}
-      />
+      <EditInvestmentForm investment={investment} labels={labels} />
     </main>
   );
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -4,7 +4,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import HomePage from './page';
 import { storage } from '../lib/storage';
 
-// Mock the storage module
 vi.mock('../lib/storage', () => ({
   storage: {
     readAll: vi.fn(),
@@ -20,24 +19,22 @@ vi.mock('next/navigation', () => ({
 
 describe('HomePage', () => {
   it('AC-001: displays a message when there are no investments', async () => {
-    // Mock storage.readAll to return an empty portfolio
     (storage.readAll as vi.Mock).mockResolvedValue({
       investments: [],
-      categories: [],
       labels: [],
     });
 
     const ResolvedHomePage = await HomePage();
     render(ResolvedHomePage);
 
-    // Expect the empty state message to be displayed
-    expect(await screen.findByText('No investments yet. Add your first one.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('No investments yet. Add your first one.'),
+    ).toBeInTheDocument();
   });
 
   it('renders an "Add investment" link that points to /add', async () => {
     (storage.readAll as vi.Mock).mockResolvedValue({
       investments: [],
-      categories: [],
       labels: [],
     });
 
@@ -50,9 +47,6 @@ describe('HomePage', () => {
   });
 
   it('AC-002, AC-003, AC-004, AC-005: displays investments in a table with correct details', async () => {
-    // Define mock data
-    const mockCategory1 = { id: 'cat1', name: 'Stocks', color: '#FF0000' };
-    const mockCategory2 = { id: 'cat2', name: 'Crypto', color: '#00FF00' };
     const mockLabel1 = { id: 'lbl1', name: 'Growth', color: '#0000FF' };
     const mockLabel2 = { id: 'lbl2', name: 'High Risk', color: '#FFFF00' };
 
@@ -60,9 +54,9 @@ describe('HomePage', () => {
       id: 'inv1',
       instrument: 'AAPL',
       amount: 10,
-      price: 150.00,
+      price: 150.0,
       purchaseDate: '2023-01-15',
-      categoryId: mockCategory1.id,
+      category: 'Stocks',
       labelIds: [mockLabel1.id],
       notes: 'Apple Stock',
     };
@@ -71,31 +65,26 @@ describe('HomePage', () => {
       id: 'inv2',
       instrument: 'ETH',
       amount: 0.5,
-      price: 2000.00,
+      price: 2000.0,
       purchaseDate: '2023-03-20',
-      categoryId: mockCategory2.id,
+      category: 'Crypto',
       labelIds: [mockLabel1.id, mockLabel2.id],
       notes: 'Ethereum',
     };
 
-    // Mock storage.readAll to return a portfolio with investments
     (storage.readAll as vi.Mock).mockResolvedValue({
       investments: [mockInvestment1, mockInvestment2],
-      categories: [mockCategory1, mockCategory2],
       labels: [mockLabel1, mockLabel2],
     });
 
     const ResolvedHomePage = await HomePage();
     render(ResolvedHomePage);
 
-    // AC-002: Ensure empty state message is NOT displayed
     expect(screen.queryByText('No investments yet. Add your first one.')).not.toBeInTheDocument();
 
-    // AC-002: Ensure a table is displayed
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
 
-    // AC-003: Ensure table headers are present
     expect(screen.getByRole('columnheader', { name: /Instrument/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /Category/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /Amount/i })).toBeInTheDocument();
@@ -104,21 +93,17 @@ describe('HomePage', () => {
     expect(screen.getByRole('columnheader', { name: /Labels/i })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: /Total invested/i })).toBeInTheDocument();
 
-    // AC-004 & AC-005: Verify investment details
     const rows = screen.getAllByRole('row');
-    // First row is the header, so data rows start from index 1
 
-    // Verify Investment 1 row (index 1)
     const investment1Row = rows[1];
     expect(within(investment1Row).getByRole('cell', { name: 'AAPL' })).toBeInTheDocument();
     expect(within(investment1Row).getByRole('cell', { name: 'Stocks' })).toBeInTheDocument();
     expect(within(investment1Row).getByRole('cell', { name: '10' })).toBeInTheDocument();
     expect(within(investment1Row).getByRole('cell', { name: '150.00' })).toBeInTheDocument();
     expect(within(investment1Row).getByRole('cell', { name: '2023-01-15' })).toBeInTheDocument();
-    expect(within(investment1Row).getByText('Growth')).toBeInTheDocument(); // Use getByText for labels as they are spans
+    expect(within(investment1Row).getByText('Growth')).toBeInTheDocument();
     expect(within(investment1Row).getByRole('cell', { name: '1500.00' })).toBeInTheDocument();
 
-    // Verify Investment 2 row (index 2)
     const investment2Row = rows[2];
     expect(within(investment2Row).getByRole('cell', { name: 'ETH' })).toBeInTheDocument();
     expect(within(investment2Row).getByRole('cell', { name: 'Crypto' })).toBeInTheDocument();
@@ -128,18 +113,16 @@ describe('HomePage', () => {
     expect(within(investment2Row).getByText('Growth')).toBeInTheDocument();
     expect(within(investment2Row).getByText('High Risk')).toBeInTheDocument();
     expect(within(investment2Row).getByRole('cell', { name: '1000.00' })).toBeInTheDocument();
-
   });
 
   describe('delete investment', () => {
-    const mockCategory = { id: 'cat1', name: 'Stocks', color: '#FF0000' };
     const mockInvestment1 = {
       id: 'inv1',
       instrument: 'AAPL',
       amount: 10,
       price: 150.0,
       purchaseDate: '2023-01-15',
-      categoryId: mockCategory.id,
+      category: 'Stocks',
       labelIds: [],
     };
     const mockInvestment2 = {
@@ -148,14 +131,13 @@ describe('HomePage', () => {
       amount: 5,
       price: 200.0,
       purchaseDate: '2023-02-20',
-      categoryId: mockCategory.id,
+      category: 'Stocks',
       labelIds: [],
     };
 
     beforeEach(() => {
       (storage.readAll as unknown as vi.Mock).mockResolvedValue({
         investments: [mockInvestment1, mockInvestment2],
-        categories: [mockCategory],
         labels: [],
       });
       vi.stubGlobal('fetch', vi.fn());
@@ -190,9 +172,7 @@ describe('HomePage', () => {
     });
 
     it('calls DELETE /api/investments/<id> when the user confirms', async () => {
-      const fetchMock = vi.fn().mockResolvedValue(
-        new Response(null, { status: 204 }),
-      );
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
       vi.stubGlobal('fetch', fetchMock);
       vi.spyOn(window, 'confirm').mockReturnValue(true);
 
@@ -231,9 +211,7 @@ describe('HomePage', () => {
     });
 
     it('shows an inline error message when the API call fails', async () => {
-      const fetchMock = vi.fn().mockResolvedValue(
-        new Response(null, { status: 500 }),
-      );
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
       vi.stubGlobal('fetch', fetchMock);
       vi.spyOn(window, 'confirm').mockReturnValue(true);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { storage } from '../lib/storage';
 import { InvestmentsTable } from './InvestmentsTable';
 
 export default async function HomePage() {
-  const { investments, categories, labels } = await storage.readAll();
+  const { investments, labels } = await storage.readAll();
 
   return (
     <main className="container mx-auto p-4">
@@ -20,11 +20,7 @@ export default async function HomePage() {
       {investments.length === 0 ? (
         <p className="text-center text-gray-500">No investments yet. Add your first one.</p>
       ) : (
-        <InvestmentsTable
-          investments={investments}
-          categories={categories}
-          labels={labels}
-        />
+        <InvestmentsTable investments={investments} labels={labels} />
       )}
     </main>
   );

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -1,9 +1,9 @@
 // lib/storage.test.ts
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { storage, _setTestDataFilePath } from './storage';
-import { Investment, Portfolio, Category, Label } from './types';
+import { Investment, Label } from './types';
 import { v4 as uuidv4 } from 'uuid';
 
 // Define a temporary directory for test data
@@ -12,27 +12,25 @@ const TEST_DATA_FILE = path.join(TEST_DATA_DIR, 'portfolio.json');
 
 describe('Storage Module', () => {
   beforeEach(async () => {
-    // Set the test data file path before each test
     _setTestDataFilePath(TEST_DATA_FILE);
-    // Ensure test data directory exists before each test
     await fs.mkdir(TEST_DATA_DIR, { recursive: true });
-    // Initialize the test file with an empty portfolio
-    await fs.writeFile(TEST_DATA_FILE, JSON.stringify({ investments: [], categories: [], labels: [] }, null, 2), 'utf-8');
+    await fs.writeFile(
+      TEST_DATA_FILE,
+      JSON.stringify({ investments: [], labels: [] }, null, 2),
+      'utf-8',
+    );
   });
 
   afterEach(async () => {
-    // Clean up the test data directory after each test
     await fs.rm(TEST_DATA_DIR, { recursive: true, force: true });
   });
 
-  // AC-003: readAll() from empty file
   it('should return an empty portfolio if the data file does not exist', async () => {
-    await fs.unlink(TEST_DATA_FILE); // Manually remove the file to simulate it not existing
+    await fs.unlink(TEST_DATA_FILE);
     const portfolio = await storage.readAll();
-    expect(portfolio).toEqual({ investments: [], categories: [], labels: [] });
+    expect(portfolio).toEqual({ investments: [], labels: [] });
   });
 
-  // AC-002: addInvestment and AC-003: readAll
   it('should add an investment and retrieve it', async () => {
     const newInvestment: Investment = {
       id: uuidv4(),
@@ -40,7 +38,7 @@ describe('Storage Module', () => {
       amount: 10,
       price: 150,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [uuidv4()],
       notes: 'Initial purchase',
     };
@@ -52,7 +50,6 @@ describe('Storage Module', () => {
     expect(portfolio.investments[0]).toEqual(newInvestment);
   });
 
-  // AC-004: updateInvestment
   it('should update an existing investment', async () => {
     const initialInvestment: Investment = {
       id: uuidv4(),
@@ -60,7 +57,7 @@ describe('Storage Module', () => {
       amount: 5,
       price: 100,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
       notes: 'Initial GOOG purchase',
     };
@@ -70,12 +67,14 @@ describe('Storage Module', () => {
     await storage.updateInvestment(initialInvestment.id, patch);
 
     const portfolio = await storage.readAll();
-    const updatedInvestment = portfolio.investments.find(inv => inv.id === initialInvestment.id);
+    const updatedInvestment = portfolio.investments.find(
+      (inv) => inv.id === initialInvestment.id,
+    );
 
     expect(updatedInvestment).toBeDefined();
     expect(updatedInvestment?.price).toBe(105);
     expect(updatedInvestment?.notes).toBe('Updated GOOG notes');
-    expect(updatedInvestment?.instrument).toBe('GOOG'); // Ensure other fields are unchanged
+    expect(updatedInvestment?.instrument).toBe('GOOG');
   });
 
   it('updateInvestment returns the updated investment on success', async () => {
@@ -85,7 +84,7 @@ describe('Storage Module', () => {
       amount: 2,
       price: 200,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
     };
     await storage.addInvestment(initial);
@@ -113,7 +112,7 @@ describe('Storage Module', () => {
       amount: 1,
       price: 500,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
     };
     await storage.addInvestment(initial);
@@ -128,10 +127,11 @@ describe('Storage Module', () => {
     const portfolio = await storage.readAll();
     expect(portfolio.investments).toHaveLength(1);
     expect(portfolio.investments[0].id).toBe(initial.id);
-    expect(portfolio.investments.find(inv => inv.id === 'attacker-supplied-id')).toBeUndefined();
+    expect(
+      portfolio.investments.find((inv) => inv.id === 'attacker-supplied-id'),
+    ).toBeUndefined();
   });
 
-  // AC-005: removeInvestment
   it('should remove an investment', async () => {
     const investmentToRemove: Investment = {
       id: uuidv4(),
@@ -139,7 +139,7 @@ describe('Storage Module', () => {
       amount: 1,
       price: 800,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
       notes: 'Investment to be removed',
     };
@@ -149,7 +149,7 @@ describe('Storage Module', () => {
       amount: 2,
       price: 3000,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
       notes: 'Investment to keep',
     };
@@ -162,7 +162,9 @@ describe('Storage Module', () => {
     const portfolio = await storage.readAll();
     expect(portfolio.investments).toHaveLength(1);
     expect(portfolio.investments[0]).toEqual(investmentToKeep);
-    expect(portfolio.investments.find(inv => inv.id === investmentToRemove.id)).toBeUndefined();
+    expect(
+      portfolio.investments.find((inv) => inv.id === investmentToRemove.id),
+    ).toBeUndefined();
   });
 
   it('deleteInvestment removes the matching investment and persists the new list', async () => {
@@ -172,7 +174,7 @@ describe('Storage Module', () => {
       amount: 3,
       price: 500,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
       notes: 'To be deleted',
     };
@@ -182,7 +184,7 @@ describe('Storage Module', () => {
       amount: 4,
       price: 120,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
       notes: 'Keeper',
     };
@@ -204,7 +206,7 @@ describe('Storage Module', () => {
       amount: 1,
       price: 100,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
     };
     await storage.addInvestment(existing);
@@ -223,7 +225,7 @@ describe('Storage Module', () => {
       amount: 1,
       price: 1,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
     };
     const b: Investment = {
@@ -232,7 +234,7 @@ describe('Storage Module', () => {
       amount: 2,
       price: 2,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
     };
     const c: Investment = {
@@ -241,7 +243,7 @@ describe('Storage Module', () => {
       amount: 3,
       price: 3,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
+      category: 'Stocks',
       labelIds: [],
     };
 
@@ -256,74 +258,6 @@ describe('Storage Module', () => {
     expect(portfolio.investments).toEqual([a, c]);
   });
 
-  // AC-006: addCategory
-  it('should add a category and retrieve it', async () => {
-    const newCategory: Category = {
-      id: uuidv4(),
-      name: 'Stocks',
-      color: '#FF0000',
-    };
-
-    await storage.addCategory(newCategory);
-
-    const portfolio = await storage.readAll();
-    expect(portfolio.categories).toHaveLength(1);
-    expect(portfolio.categories[0]).toEqual(newCategory);
-  });
-
-  // AC-007: removeCategory (successful)
-  it('should remove a category if it is not linked to any investment', async () => {
-    const categoryToRemove: Category = {
-      id: uuidv4(),
-      name: 'Bonds',
-      color: '#0000FF',
-    };
-    const categoryToKeep: Category = {
-      id: uuidv4(),
-      name: 'Crypto',
-      color: '#CCCCCC',
-    };
-
-    await storage.addCategory(categoryToRemove);
-    await storage.addCategory(categoryToKeep);
-
-    await storage.removeCategory(categoryToRemove.id);
-
-    const portfolio = await storage.readAll();
-    expect(portfolio.categories).toHaveLength(1);
-    expect(portfolio.categories[0]).toEqual(categoryToKeep);
-    expect(portfolio.categories.find(cat => cat.id === categoryToRemove.id)).toBeUndefined();
-  });
-
-  // AC-008: removeCategory (failure if in use)
-  it('should fail to remove a category if it is linked to an investment', async () => {
-    const categoryInUse: Category = {
-      id: uuidv4(),
-      name: 'Stocks',
-      color: '#FF0000',
-    };
-    await storage.addCategory(categoryInUse);
-
-    const investment: Investment = {
-      id: uuidv4(),
-      instrument: 'MSFT',
-      amount: 10,
-      price: 200,
-      purchaseDate: new Date().toISOString(),
-      categoryId: categoryInUse.id, // Linked to the category
-      labelIds: [],
-      notes: 'Investment using category',
-    };
-    await storage.addInvestment(investment);
-
-    await expect(storage.removeCategory(categoryInUse.id)).rejects.toThrow('Category is in use by investments and cannot be removed.');
-
-    const portfolio = await storage.readAll();
-    expect(portfolio.categories).toHaveLength(1);
-    expect(portfolio.categories[0]).toEqual(categoryInUse); // Ensure category is still there
-  });
-
-  // AC-009: addLabel
   it('should add a label and retrieve it', async () => {
     const newLabel: Label = {
       id: uuidv4(),
@@ -338,7 +272,6 @@ describe('Storage Module', () => {
     expect(portfolio.labels[0]).toEqual(newLabel);
   });
 
-  // AC-010: removeLabel (strips from investments)
   it('should remove a label and strip it from investments that reference it', async () => {
     const labelToRemove: Label = {
       id: uuidv4(),
@@ -359,8 +292,8 @@ describe('Storage Module', () => {
       amount: 1,
       price: 50000,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
-      labelIds: [labelToRemove.id, labelToKeep.id], // References both
+      category: 'Crypto',
+      labelIds: [labelToRemove.id, labelToKeep.id],
       notes: 'Crypto investment',
     };
     const investment2: Investment = {
@@ -369,8 +302,8 @@ describe('Storage Module', () => {
       amount: 5,
       price: 3000,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
-      labelIds: [labelToRemove.id], // References only labelToRemove
+      category: 'Crypto',
+      labelIds: [labelToRemove.id],
       notes: 'Another crypto investment',
     };
     const investment3: Investment = {
@@ -379,32 +312,98 @@ describe('Storage Module', () => {
       amount: 10,
       price: 400,
       purchaseDate: new Date().toISOString(),
-      categoryId: uuidv4(),
-      labelIds: [], // References no labels
+      category: 'Stocks',
+      labelIds: [],
       notes: 'ETF investment',
     };
     await storage.addInvestment(investment1);
     await storage.addInvestment(investment2);
     await storage.addInvestment(investment3);
 
-    // This call will fail until removeLabel is implemented
     await storage.removeLabel(labelToRemove.id);
 
     const portfolio = await storage.readAll();
 
-    // Assert label is removed
     expect(portfolio.labels).toHaveLength(1);
     expect(portfolio.labels[0]).toEqual(labelToKeep);
-    expect(portfolio.labels.find(lbl => lbl.id === labelToRemove.id)).toBeUndefined();
+    expect(portfolio.labels.find((lbl) => lbl.id === labelToRemove.id)).toBeUndefined();
 
-    // Assert label is stripped from investments
-    const updatedInvestment1 = portfolio.investments.find(inv => inv.id === investment1.id);
+    const updatedInvestment1 = portfolio.investments.find((inv) => inv.id === investment1.id);
     expect(updatedInvestment1?.labelIds).toEqual([labelToKeep.id]);
 
-    const updatedInvestment2 = portfolio.investments.find(inv => inv.id === investment2.id);
-    expect(updatedInvestment2?.labelIds).toEqual([]); // Should be empty
+    const updatedInvestment2 = portfolio.investments.find((inv) => inv.id === investment2.id);
+    expect(updatedInvestment2?.labelIds).toEqual([]);
 
-    const updatedInvestment3 = portfolio.investments.find(inv => inv.id === investment3.id);
-    expect(updatedInvestment3?.labelIds).toEqual([]); // Should remain empty
+    const updatedInvestment3 = portfolio.investments.find((inv) => inv.id === investment3.id);
+    expect(updatedInvestment3?.labelIds).toEqual([]);
+  });
+
+  describe('legacy category backfill', () => {
+    it('reads investments without a category as category "Other"', async () => {
+      const legacyRecord = {
+        id: 'inv-legacy',
+        instrument: 'LEGACY',
+        amount: 1,
+        price: 10,
+        purchaseDate: '2026-01-01',
+        labelIds: [],
+      };
+      const fileContents = {
+        investments: [legacyRecord],
+        labels: [],
+      };
+      await fs.writeFile(TEST_DATA_FILE, JSON.stringify(fileContents, null, 2), 'utf-8');
+
+      const portfolio = await storage.readAll();
+
+      expect(portfolio.investments).toHaveLength(1);
+      expect(portfolio.investments[0]).toEqual({
+        ...legacyRecord,
+        category: 'Other',
+      });
+    });
+
+    it('does not rewrite the file when backfilling missing categories on read', async () => {
+      const legacyRecord = {
+        id: 'inv-legacy',
+        instrument: 'LEGACY',
+        amount: 1,
+        price: 10,
+        purchaseDate: '2026-01-01',
+        labelIds: [],
+      };
+      const fileContents = {
+        investments: [legacyRecord],
+        labels: [],
+      };
+      const serialized = JSON.stringify(fileContents, null, 2);
+      await fs.writeFile(TEST_DATA_FILE, serialized, 'utf-8');
+
+      await storage.readAll();
+
+      const onDisk = await fs.readFile(TEST_DATA_FILE, 'utf-8');
+      expect(onDisk).toBe(serialized);
+    });
+
+    it('preserves an explicit category from disk', async () => {
+      const record = {
+        id: 'inv-1',
+        instrument: 'AAPL',
+        amount: 1,
+        price: 100,
+        purchaseDate: '2026-01-01',
+        category: 'Stocks',
+        labelIds: [],
+      };
+      await fs.writeFile(
+        TEST_DATA_FILE,
+        JSON.stringify({ investments: [record], labels: [] }, null, 2),
+        'utf-8',
+      );
+
+      const portfolio = await storage.readAll();
+
+      expect(portfolio.investments[0].category).toBe('Stocks');
+    });
   });
 });

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,37 +1,45 @@
 // lib/storage.ts
-import { Investment, Category, Label, Portfolio } from './types';
+import { Investment, Label } from './types';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-// Made mutable for testing purposes. In a real app, this would likely be a constant
-// or passed via dependency injection.
 let currentDataFilePath = path.join(process.cwd(), 'data', 'portfolio.json');
 
-// For testing purposes, allow setting a different data file path
 export function _setTestDataFilePath(filePath: string) {
   currentDataFilePath = filePath;
 }
 
 interface PortfolioData {
   investments: Investment[];
-  categories: Category[];
   labels: Label[];
 }
 
-// Helper function to ensure the data directory exists
 async function ensureDataDirectory() {
   const dataDir = path.dirname(currentDataFilePath);
   await fs.mkdir(dataDir, { recursive: true });
 }
 
+function backfillInvestment(raw: Partial<Investment> & Record<string, unknown>): Investment {
+  if (raw.category) {
+    return raw as Investment;
+  }
+  return { ...(raw as Investment), category: 'Other' };
+}
+
 async function _readAll(): Promise<PortfolioData> {
   try {
     const data = await fs.readFile(currentDataFilePath, 'utf-8');
-    return JSON.parse(data);
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
-      // If file doesn't exist, return an empty portfolio
-      return { investments: [], categories: [], labels: [] };
+    const parsed = JSON.parse(data) as {
+      investments?: Array<Partial<Investment> & Record<string, unknown>>;
+      labels?: Label[];
+    };
+    return {
+      investments: (parsed.investments ?? []).map(backfillInvestment),
+      labels: parsed.labels ?? [],
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { investments: [], labels: [] };
     }
     throw error;
   }
@@ -48,9 +56,12 @@ async function addInvestment(investment: Investment): Promise<void> {
   await _writeAll(portfolio);
 }
 
-async function updateInvestment(id: string, patch: Partial<Investment>): Promise<Investment | null> {
+async function updateInvestment(
+  id: string,
+  patch: Partial<Investment>,
+): Promise<Investment | null> {
   const portfolio = await _readAll();
-  const index = portfolio.investments.findIndex(inv => inv.id === id);
+  const index = portfolio.investments.findIndex((inv) => inv.id === id);
   if (index === -1) {
     return null;
   }
@@ -63,33 +74,17 @@ async function updateInvestment(id: string, patch: Partial<Investment>): Promise
 
 async function removeInvestment(id: string): Promise<void> {
   const portfolio = await _readAll();
-  portfolio.investments = portfolio.investments.filter(inv => inv.id !== id);
+  portfolio.investments = portfolio.investments.filter((inv) => inv.id !== id);
   await _writeAll(portfolio);
 }
 
 async function deleteInvestment(id: string): Promise<void> {
   const portfolio = await _readAll();
-  const index = portfolio.investments.findIndex(inv => inv.id === id);
+  const index = portfolio.investments.findIndex((inv) => inv.id === id);
   if (index === -1) {
     throw new Error(`Investment with id "${id}" not found.`);
   }
   portfolio.investments.splice(index, 1);
-  await _writeAll(portfolio);
-}
-
-async function addCategory(category: Category): Promise<void> {
-  const portfolio = await _readAll();
-  portfolio.categories.push(category);
-  await _writeAll(portfolio);
-}
-
-async function removeCategory(id: string): Promise<void> {
-  const portfolio = await _readAll();
-  const categoryInUse = portfolio.investments.some(inv => inv.categoryId === id);
-  if (categoryInUse) {
-    throw new Error('Category is in use by investments and cannot be removed.');
-  }
-  portfolio.categories = portfolio.categories.filter(cat => cat.id !== id);
   await _writeAll(portfolio);
 }
 
@@ -101,26 +96,20 @@ async function addLabel(label: Label): Promise<void> {
 
 async function removeLabel(id: string): Promise<void> {
   const portfolio = await _readAll();
-  // Remove the label from the labels array
-  portfolio.labels = portfolio.labels.filter(lbl => lbl.id !== id);
-
-  // Strip the label ID from all investments
-  portfolio.investments = portfolio.investments.map(inv => ({
+  portfolio.labels = portfolio.labels.filter((lbl) => lbl.id !== id);
+  portfolio.investments = portfolio.investments.map((inv) => ({
     ...inv,
-    labelIds: inv.labelIds.filter(labelId => labelId !== id),
+    labelIds: inv.labelIds.filter((labelId) => labelId !== id),
   }));
-
   await _writeAll(portfolio);
 }
 
 export const storage = {
   readAll: _readAll,
-  addInvestment: addInvestment,
-  updateInvestment: updateInvestment,
-  removeInvestment: removeInvestment,
-  deleteInvestment: deleteInvestment,
-  addCategory: addCategory,
-  removeCategory: removeCategory,
-  addLabel: addLabel,
-  removeLabel: removeLabel, // Export removeLabel
+  addInvestment,
+  updateInvestment,
+  removeInvestment,
+  deleteInvestment,
+  addLabel,
+  removeLabel,
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,20 +1,25 @@
 // lib/types.ts
 
+export const CATEGORIES = [
+  'Stocks',
+  'Crypto',
+  'Real Estate',
+  'Bonds',
+  'Cash',
+  'Other',
+] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+
 export interface Investment {
   id: string; // uuid
   instrument: string; // e.g., "AAPL" or "BTC"
   amount: number; // how many units
   price: number; // price per unit at purchase
   purchaseDate: string; // ISO date string
-  categoryId: string; // reference to Category.id
+  category: Category;
   labelIds: string[]; // array of references to Label.id
   notes?: string; // optional string
-}
-
-export interface Category {
-  id: string; // uuid
-  name: string; // e.g., "Stocks", "Crypto", "Bonds"
-  color: string; // hex string
 }
 
 export interface Label {
@@ -25,6 +30,5 @@ export interface Label {
 
 export interface Portfolio {
   investments: Investment[];
-  categories: Category[];
   labels: Label[];
 }


### PR DESCRIPTION
Closes #11

## Add categories to investments

Recovered from timed-out autonomous run: Claude Code CLI finished implementing but the 10-min process spawn timeout killed it before the commit/push step. All 58 tests pass locally.

### Changes
```
 lib/storage.test.ts                       | 225 +++++++++++++++---------------
 lib/storage.ts                            |  81 +++++------
 lib/types.ts                              |  22 +--
 package-lock.json                         |  12 +-
 20 files changed, 438 insertions(+), 316 deletions(-)
```

---
*Implemented by Developer Agent + manual recovery after timeout.*