### PR TITLE
feat: feat: Users can set a purchase date when creating an investment

### DIFF
--- a/app/add/page.test.tsx
+++ b/app/add/page.test.tsx
@@ -165,6 +165,53 @@ describe('AddPage', () => {
     expect(body.category).toBe('Crypto');
   });
 
+  it('submits the chosen purchase date in the POST payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const Resolved = await AddPage();
+    render(Resolved);
+
+    fireEvent.change(screen.getByLabelText(/instrument/i), { target: { value: 'AAPL' } });
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: '150' } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Stocks' } });
+    fireEvent.change(screen.getByLabelText(/purchase date/i), {
+      target: { value: '2025-07-04' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.purchaseDate).toBe('2025-07-04');
+  });
+
+  it('submits the default (today) purchase date when the user does not change it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const Resolved = await AddPage();
+    render(Resolved);
+
+    fireEvent.change(screen.getByLabelText(/instrument/i), { target: { value: 'AAPL' } });
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '10' } });
+    fireEvent.change(screen.getByLabelText(/price/i), { target: { value: '150' } });
+    fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Stocks' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.purchaseDate).toBe(today);
+  });
+
   describe('custom labels (free-text chips)', () => {
     function getLabelsInput(): HTMLInputElement {
       return screen.getByPlaceholderText(/add a label/i) as HTMLInputElement;

--- a/app/api/investments/route.test.ts
+++ b/app/api/investments/route.test.ts
@@ -139,6 +139,59 @@ describe('POST /api/investments', () => {
     expect(storage.addInvestment).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when purchaseDate is missing', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 10,
+      price: 150,
+      category: 'Stocks',
+      labelIds: [],
+    };
+
+    const response = await POST(makeRequest(payload));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
+    expect(body.error).toMatch(/purchaseDate/i);
+    expect(storage.addInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when purchaseDate is not a valid ISO date', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 10,
+      price: 150,
+      purchaseDate: 'not-a-date',
+      category: 'Stocks',
+      labelIds: [],
+    };
+
+    const response = await POST(makeRequest(payload));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
+    expect(body.error).toMatch(/purchaseDate/i);
+    expect(storage.addInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when purchaseDate is not in YYYY-MM-DD format', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 10,
+      price: 150,
+      purchaseDate: '15/01/2026',
+      category: 'Stocks',
+      labelIds: [],
+    };
+
+    const response = await POST(makeRequest(payload));
+
+    expect(response.status).toBe(400);
+    expect(storage.addInvestment).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when category is missing', async () => {
     const payload = {
       instrument: 'AAPL',

--- a/app/api/investments/schema.ts
+++ b/app/api/investments/schema.ts
@@ -23,7 +23,7 @@ export const investmentSchema = z.object({
   instrument: z.string().trim().min(1, 'Instrument is required'),
   amount: z.number().positive('Amount must be a positive number'),
   price: z.number().positive('Price must be a positive number'),
-  purchaseDate: z.string().min(1, 'Purchase date is required'),
+  purchaseDate: z.iso.date('Purchase date must be a valid ISO date (YYYY-MM-DD)'),
   category: z.enum(CATEGORIES, {
     message: `Category must be one of: ${CATEGORIES.join(', ')}`,
   }),


### PR DESCRIPTION
Closes #31

## feat: Users can set a purchase date when creating an investment

### Changes
```
app/add/page.test.tsx             | 47 ++++++++++++++++++++++++++++++++++
 app/api/investments/route.test.ts | 53 +++++++++++++++++++++++++++++++++++++++
 app/api/investments/schema.ts     |  2 +-
 3 files changed, 101 insertions(+), 1 deletion(-)
```

---
*Implemented by Developer Agent.*