### PR TITLE
feat: feat: Users can edit the purchase date when editing an investment

### DIFF
--- a/app/api/investments/[id]/route.test.ts
+++ b/app/api/investments/[id]/route.test.ts
@@ -239,6 +239,60 @@ describe('PUT /api/investments/[id]', () => {
     );
   });
 
+  it('updates the stored purchaseDate when a valid new date is provided', async () => {
+    const updated: Investment = {
+      id: 'inv-001',
+      labels: [],
+      ...validPayload,
+      purchaseDate: '2024-06-30',
+    };
+    (storage.updateInvestment as unknown as vi.Mock).mockResolvedValue(updated);
+
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, purchaseDate: '2024-06-30' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(storage.updateInvestment).toHaveBeenCalledWith(
+      'inv-001',
+      expect.objectContaining({ purchaseDate: '2024-06-30' }),
+    );
+
+    const body = (await response.json()) as Investment;
+    expect(body.purchaseDate).toBe('2024-06-30');
+  });
+
+  it('returns 400 when purchaseDate is empty', async () => {
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, purchaseDate: '' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(storage.updateInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when purchaseDate is malformed', async () => {
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, purchaseDate: 'not-a-date' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(storage.updateInvestment).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when purchaseDate has impossible month/day values', async () => {
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, purchaseDate: '2025-13-40' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(storage.updateInvestment).not.toHaveBeenCalled();
+  });
+
   it('ignores a client-provided id in the payload', async () => {
     const updated: Investment = { id: 'inv-001', labels: [], ...validPayload };
     (storage.updateInvestment as unknown as vi.Mock).mockResolvedValue(updated);

--- a/app/edit/[id]/EditInvestmentForm.test.tsx
+++ b/app/edit/[id]/EditInvestmentForm.test.tsx
@@ -50,6 +50,37 @@ describe('EditInvestmentForm', () => {
     expect(category.value).toBe('Stocks');
   });
 
+  it('pre-fills the purchase date input with the investment current value', () => {
+    render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+    const purchaseDate = screen.getByLabelText(/purchase date/i) as HTMLInputElement;
+    expect(purchaseDate.value).toBe('2026-01-15');
+  });
+
+  it('sends the new purchase date when changed and submitted', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ...investment, purchaseDate: '2024-06-30' }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+    fireEvent.change(screen.getByLabelText(/purchase date/i), {
+      target: { value: '2024-06-30' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.purchaseDate).toBe('2024-06-30');
+  });
+
   it('submits a PUT /api/investments/<id> request with the edited payload', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ...investment, price: 175 }), { status: 200 }),


### PR DESCRIPTION
Closes #54

## feat: Users can edit the purchase date when editing an investment

### Changes
```
app/api/investments/[id]/route.test.ts    | 54 +++++++++++++++++++++++++++++++
 app/edit/[id]/EditInvestmentForm.test.tsx | 31 ++++++++++++++++++
 2 files changed, 85 insertions(+)
```

---
*Implemented by Developer Agent.*