### PR TITLE
feat: feat: Users can add notes when creating an investment

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,6 +15,7 @@ Format: `- <one-line capability from the user's perspective> — \`<primary file
 - Users can pick a category from a fixed list when creating an investment — `app/add/AddInvestmentForm.tsx`
 - Users can attach custom labels when creating an investment — `app/add/AddInvestmentForm.tsx`
 - Users can set a purchase date when creating an investment — `app/add/AddInvestmentForm.tsx`
+- Users can add free-form notes when creating an investment — `app/add/AddInvestmentForm.tsx`
 
 ## Edit
 

--- a/app/add/page.test.tsx
+++ b/app/add/page.test.tsx
@@ -212,6 +212,55 @@ describe('AddPage', () => {
     expect(body.purchaseDate).toBe(today);
   });
 
+  describe('notes', () => {
+    it('submits the notes value in the POST payload when the user fills the textarea', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const Resolved = await AddPage();
+      render(Resolved);
+
+      fireEvent.change(screen.getByLabelText(/instrument/i), { target: { value: 'AAPL' } });
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '10' } });
+      fireEvent.change(screen.getByLabelText(/price/i), { target: { value: '150' } });
+      fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Stocks' } });
+      fireEvent.change(screen.getByLabelText(/notes/i), {
+        target: { value: 'Bought after earnings beat' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body.notes).toBe('Bought after earnings beat');
+    });
+
+    it('omits notes from the POST payload when the textarea is left empty', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const Resolved = await AddPage();
+      render(Resolved);
+
+      fireEvent.change(screen.getByLabelText(/instrument/i), { target: { value: 'AAPL' } });
+      fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '10' } });
+      fireEvent.change(screen.getByLabelText(/price/i), { target: { value: '150' } });
+      fireEvent.change(screen.getByLabelText(/category/i), { target: { value: 'Stocks' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body).not.toHaveProperty('notes');
+    });
+  });
+
   describe('custom labels (free-text chips)', () => {
     function getLabelsInput(): HTMLInputElement {
       return screen.getByPlaceholderText(/add a label/i) as HTMLInputElement;

--- a/app/api/investments/route.test.ts
+++ b/app/api/investments/route.test.ts
@@ -53,6 +53,81 @@ describe('POST /api/investments', () => {
     expect(storage.addInvestment).toHaveBeenCalledWith(body);
   });
 
+  it('creates the investment without notes when notes is omitted', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 10,
+      price: 150,
+      purchaseDate: '2026-01-15',
+      category: 'Stocks',
+      labelIds: [],
+    };
+
+    const response = await POST(makeRequest(payload));
+    const body = (await response.json()) as Investment;
+
+    expect(response.status).toBe(201);
+    expect(body.notes).toBeUndefined();
+    expect(storage.addInvestment).toHaveBeenCalledWith(
+      expect.not.objectContaining({ notes: expect.anything() }),
+    );
+  });
+
+  it('treats an empty-string notes as not provided', async () => {
+    const payload = {
+      instrument: 'AAPL',
+      amount: 10,
+      price: 150,
+      purchaseDate: '2026-01-15',
+      category: 'Stocks',
+      labelIds: [],
+      notes: '',
+    };
+
+    const response = await POST(makeRequest(payload));
+    const body = (await response.json()) as Investment;
+
+    expect(response.status).toBe(201);
+    expect(body.notes).toBeUndefined();
+    expect(storage.addInvestment).toHaveBeenCalledWith(
+      expect.not.objectContaining({ notes: expect.anything() }),
+    );
+  });
+
+  it('treats whitespace-only notes as not provided and trims meaningful notes', async () => {
+    const blankResponse = await POST(
+      makeRequest({
+        instrument: 'AAPL',
+        amount: 10,
+        price: 150,
+        purchaseDate: '2026-01-15',
+        category: 'Stocks',
+        labelIds: [],
+        notes: '   \n\t  ',
+      }),
+    );
+    const blankBody = (await blankResponse.json()) as Investment;
+
+    expect(blankResponse.status).toBe(201);
+    expect(blankBody.notes).toBeUndefined();
+
+    const trimmedResponse = await POST(
+      makeRequest({
+        instrument: 'BTC',
+        amount: 0.5,
+        price: 60000,
+        purchaseDate: '2026-02-01',
+        category: 'Crypto',
+        labelIds: [],
+        notes: '  Bought after dip  ',
+      }),
+    );
+    const trimmedBody = (await trimmedResponse.json()) as Investment;
+
+    expect(trimmedResponse.status).toBe(201);
+    expect(trimmedBody.notes).toBe('Bought after dip');
+  });
+
   it('generates the id server-side and ignores any client-provided id', async () => {
     const payload = {
       id: 'malicious-client-id',

--- a/app/api/investments/schema.ts
+++ b/app/api/investments/schema.ts
@@ -32,5 +32,14 @@ export const investmentSchema = z.object({
     .array(z.string(), { message: 'labels must be an array of strings' })
     .optional()
     .transform((raw) => (raw === undefined ? undefined : sanitizeLabels(raw))),
-  notes: z.string().optional(),
+  notes: z
+    .string()
+    .optional()
+    .transform((raw) => {
+      if (raw === undefined) {
+        return undefined;
+      }
+      const trimmed = raw.trim();
+      return trimmed.length === 0 ? undefined : trimmed;
+    }),
 });


### PR DESCRIPTION
Closes #64

## feat: Users can add notes when creating an investment

### Changes
```
FEATURES.md                       |  1 +
 app/add/page.test.tsx             | 49 +++++++++++++++++++++++++
 app/api/investments/route.test.ts | 75 +++++++++++++++++++++++++++++++++++++++
 app/api/investments/schema.ts     | 11 +++++-
 4 files changed, 135 insertions(+), 1 deletion(-)
```

---
*Implemented by Developer Agent.*