### PR TITLE
feat: feat: Users can edit the notes of an investment

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,6 +23,7 @@ Format: `- <one-line capability from the user's perspective> — \`<primary file
 - Users can edit the custom labels of an investment — `app/edit/[id]/EditInvestmentForm.tsx`
 - Users can edit the purchase date of an investment — `app/edit/[id]/EditInvestmentForm.tsx`
 - Users can change the category of an investment while editing — `app/edit/[id]/EditInvestmentForm.tsx`
+- Users can edit or clear the notes of an existing investment — `app/edit/[id]/EditInvestmentForm.tsx`
 
 ## Delete
 

--- a/app/api/investments/[id]/route.test.ts
+++ b/app/api/investments/[id]/route.test.ts
@@ -293,6 +293,26 @@ describe('PUT /api/investments/[id]', () => {
     expect(storage.updateInvestment).not.toHaveBeenCalled();
   });
 
+  it('clears the stored notes when the payload notes field is an empty string', async () => {
+    const updated: Investment = {
+      id: 'inv-001',
+      labels: [],
+      ...validPayload,
+      notes: undefined,
+    };
+    (storage.updateInvestment as unknown as vi.Mock).mockResolvedValue(updated);
+
+    const response = await PUT(
+      makePutRequest('inv-001', { ...validPayload, notes: '' }),
+      makeContext('inv-001'),
+    );
+
+    expect(response.status).toBe(200);
+    const patch = (storage.updateInvestment as unknown as vi.Mock).mock.calls[0][1];
+    expect('notes' in patch).toBe(true);
+    expect(patch.notes).toBeUndefined();
+  });
+
   it('ignores a client-provided id in the payload', async () => {
     const updated: Investment = { id: 'inv-001', labels: [], ...validPayload };
     (storage.updateInvestment as unknown as vi.Mock).mockResolvedValue(updated);

--- a/app/api/investments/[id]/route.ts
+++ b/app/api/investments/[id]/route.ts
@@ -42,6 +42,9 @@ export async function PUT(
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
+  const notesWasSent =
+    typeof payload === 'object' && payload !== null && 'notes' in payload;
+
   const patch: Partial<Investment> = {
     instrument: parsed.data.instrument,
     amount: parsed.data.amount,
@@ -50,7 +53,7 @@ export async function PUT(
     category: parsed.data.category,
     labelIds: parsed.data.labelIds,
     ...(parsed.data.labels !== undefined && { labels: parsed.data.labels }),
-    ...(parsed.data.notes !== undefined && { notes: parsed.data.notes }),
+    ...(notesWasSent && { notes: parsed.data.notes }),
   };
 
   const updated = await storage.updateInvestment(id, patch);

--- a/app/edit/[id]/EditInvestmentForm.test.tsx
+++ b/app/edit/[id]/EditInvestmentForm.test.tsx
@@ -212,6 +212,72 @@ describe('EditInvestmentForm', () => {
     });
   });
 
+  describe('notes', () => {
+    it('pre-fills the notes textarea with the investment current notes', () => {
+      render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+      const notes = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+      expect(notes.value).toBe('Initial position');
+    });
+
+    it('renders an empty textarea when the investment has no notes', () => {
+      const withoutNotes: Investment = { ...investment, notes: undefined };
+      render(<EditInvestmentForm investment={withoutNotes} labels={labels} />);
+
+      const notes = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+      expect(notes.value).toBe('');
+    });
+
+    it('sends the edited notes in the PUT body when changed and submitted', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ...investment, notes: 'Revised thesis' }), {
+          status: 200,
+        }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+      fireEvent.change(screen.getByLabelText(/notes/i), {
+        target: { value: 'Revised thesis' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body.notes).toBe('Revised thesis');
+    });
+
+    it('sends an empty notes value when the textarea is cleared and submitted', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ...investment, notes: undefined }), {
+          status: 200,
+        }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      render(<EditInvestmentForm investment={investment} labels={labels} />);
+
+      fireEvent.change(screen.getByLabelText(/notes/i), {
+        target: { value: '' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body).toHaveProperty('notes');
+      expect(body.notes).toBe('');
+    });
+  });
+
   it('shows an inline error message when the server returns an error', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: 'something broke' }), { status: 500 }),

--- a/app/edit/[id]/EditInvestmentForm.tsx
+++ b/app/edit/[id]/EditInvestmentForm.tsx
@@ -84,7 +84,7 @@ export function EditInvestmentForm({ investment, labels }: EditInvestmentFormPro
       category,
       labelIds,
       labels: submittedLabels,
-      ...(notes && { notes }),
+      notes,
     };
 
     startTransition(async () => {


### PR DESCRIPTION
Closes #70

## feat: Users can edit the notes of an investment

### Changes
```
FEATURES.md                               |  1 +
 app/api/investments/[id]/route.test.ts    | 20 ++++++++++
 app/api/investments/[id]/route.ts         |  5 ++-
 app/edit/[id]/EditInvestmentForm.test.tsx | 66 +++++++++++++++++++++++++++++++
 app/edit/[id]/EditInvestmentForm.tsx      |  2 +-
 5 files changed, 92 insertions(+), 2 deletions(-)
```

---
*Implemented by Developer Agent.*