### PR TITLE
feat: feat: Users can filter investments list by notes presence

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,6 +52,7 @@ Format: `- <one-line capability from the user's perspective> — \`<primary file
 - Users can search investments by text contained in their notes through the unified search box — `app/InvestmentsTable.tsx`
 - Users can filter investments by a purchase amount range (min/max) — `app/InvestmentsTable.tsx`
 - Users can clear all active filters at once with a single "Clear filters" button — `app/InvestmentsTable.tsx`
+- Users can toggle an "Only with notes" filter to show only investments whose notes are non-empty — `app/InvestmentsTable.tsx`
 
 ## Sort
 

--- a/app/InvestmentsTable.tsx
+++ b/app/InvestmentsTable.tsx
@@ -27,6 +27,7 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
   const [toDate, setToDate] = useState<string>('');
   const [minAmount, setMinAmount] = useState<string>('');
   const [maxAmount, setMaxAmount] = useState<string>('');
+  const [onlyWithNotes, setOnlyWithNotes] = useState<boolean>(false);
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [dateSortDirection, setDateSortDirection] = useState<SortDirection>(null);
   const [nameSortDirection, setNameSortDirection] = useState<SortDirection>(null);
@@ -96,6 +97,9 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
       if (maxAmountBound !== null && investment.amount > maxAmountBound) {
         return false;
       }
+      if (onlyWithNotes && (investment.notes ?? '').trim() === '') {
+        return false;
+      }
       return true;
     });
   }, [
@@ -107,6 +111,7 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
     toDate,
     minAmountBound,
     maxAmountBound,
+    onlyWithNotes,
   ]);
 
   const displayedInvestments = useMemo(() => {
@@ -263,7 +268,8 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
     fromDate !== '' ||
     toDate !== '' ||
     minAmount !== '' ||
-    maxAmount !== '';
+    maxAmount !== '' ||
+    onlyWithNotes;
 
   const isFiltered =
     categoryFilter !== '' ||
@@ -272,7 +278,8 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
     fromDate !== '' ||
     toDate !== '' ||
     minAmountBound !== null ||
-    maxAmountBound !== null;
+    maxAmountBound !== null ||
+    onlyWithNotes;
 
   const totalInvestedLabel = isFiltered ? 'Total invested (filtered)' : 'Total invested';
 
@@ -284,6 +291,7 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
     setToDate('');
     setMinAmount('');
     setMaxAmount('');
+    setOnlyWithNotes(false);
   }
 
   const filteredCount = filteredInvestments.length;
@@ -484,6 +492,18 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
             onChange={(event) => setMaxAmount(event.target.value)}
             className="border border-gray-300 rounded px-3 py-2"
           />
+        </div>
+        <div className="flex items-end">
+          <label htmlFor="only-with-notes" className="inline-flex items-center gap-2 text-sm font-medium">
+            <input
+              id="only-with-notes"
+              type="checkbox"
+              checked={onlyWithNotes}
+              onChange={(event) => setOnlyWithNotes(event.target.checked)}
+              className="h-4 w-4"
+            />
+            Only with notes
+          </label>
         </div>
         {hasActiveFilters && (
           <div className="flex items-end">

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -3740,4 +3740,124 @@ describe('HomePage', () => {
       expect(visibleInstruments()).toEqual(['AAPL', 'BTC', 'US10Y']);
     });
   });
+
+  describe('issue #81: filter investments list by notes presence', () => {
+    const invWithNotes = {
+      id: 'inv-with-notes',
+      instrument: 'AAPL',
+      amount: 10,
+      price: 150,
+      purchaseDate: '2026-03-01',
+      category: 'Stocks',
+      labelIds: [],
+      labels: [],
+      notes: 'Bought after earnings call',
+    };
+
+    const invWithEmptyNotes = {
+      id: 'inv-empty-notes',
+      instrument: 'MSFT',
+      amount: 5,
+      price: 100,
+      purchaseDate: '2026-02-15',
+      category: 'Stocks',
+      labelIds: [],
+      labels: [],
+      notes: '',
+    };
+
+    const invWithWhitespaceNotes = {
+      id: 'inv-ws-notes',
+      instrument: 'GOOG',
+      amount: 3,
+      price: 200,
+      purchaseDate: '2026-02-20',
+      category: 'Stocks',
+      labelIds: [],
+      labels: [],
+      notes: '   ',
+    };
+
+    const invWithoutNotes = {
+      id: 'inv-no-notes',
+      instrument: 'BTC',
+      amount: 2,
+      price: 50,
+      purchaseDate: '2026-02-25',
+      category: 'Crypto',
+      labelIds: [],
+      labels: [],
+    };
+
+    function visibleInstruments() {
+      const table = screen.queryByRole('table');
+      if (!table) {
+        return [] as string[];
+      }
+      const bodyRows = within(table).getAllByRole('row').slice(1);
+      return bodyRows.map((row) => {
+        const firstCell = within(row).getAllByRole('cell')[0];
+        const nameSpan = firstCell.querySelector('span');
+        return nameSpan?.textContent?.trim() ?? '';
+      });
+    }
+
+    it('AC-001: checking "Only with notes" leaves only investments with non-empty notes', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [invWithNotes, invWithEmptyNotes, invWithWhitespaceNotes, invWithoutNotes],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      const onlyWithNotes = screen.getByLabelText('Only with notes') as HTMLInputElement;
+      expect(onlyWithNotes.checked).toBe(false);
+      fireEvent.click(onlyWithNotes);
+      expect(onlyWithNotes.checked).toBe(true);
+
+      const instruments = visibleInstruments();
+      expect(instruments).toEqual(['AAPL']);
+    });
+
+    it('AC-002: "Clear filters" also unchecks "Only with notes" and restores all rows', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [invWithNotes, invWithEmptyNotes, invWithoutNotes],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      const onlyWithNotes = screen.getByLabelText('Only with notes') as HTMLInputElement;
+      fireEvent.click(onlyWithNotes);
+      expect(onlyWithNotes.checked).toBe(true);
+      expect(visibleInstruments()).toEqual(['AAPL']);
+
+      const clearButton = screen.getByRole('button', { name: /clear filters/i });
+      fireEvent.click(clearButton);
+
+      expect(onlyWithNotes.checked).toBe(false);
+      const instruments = visibleInstruments();
+      expect(instruments).toContain('AAPL');
+      expect(instruments).toContain('MSFT');
+      expect(instruments).toContain('BTC');
+    });
+
+    it('AC-003: totals and match count reflect the filtered set when "Only with notes" is on', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [invWithNotes, invWithEmptyNotes, invWithoutNotes],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      const onlyWithNotes = screen.getByLabelText('Only with notes') as HTMLInputElement;
+      fireEvent.click(onlyWithNotes);
+
+      expect(screen.getByText(/showing 1 investment/i)).toBeInTheDocument();
+      expect(screen.getByText('Total invested (filtered): $10')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Closes #81

## feat: Users can filter investments list by notes presence

### Changes
```
FEATURES.md              |   1 +
 app/InvestmentsTable.tsx |  24 +++++++++-
 app/page.test.tsx        | 120 +++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 143 insertions(+), 2 deletions(-)
```

---
*Implemented by Developer Agent.*