### PR TITLE
feat: feat: Users can see min and max purchase amount in the filtered summary

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -44,6 +44,7 @@ Format: `- <one-line capability from the user's perspective> — \`<primary file
 - List shows each investment's notes, truncated with the full text on hover — `app/InvestmentsTable.tsx`
 - List shows the average purchase amount (mean of amount × price) for the currently filtered view — `app/InvestmentsTable.tsx`
 - List shows the median purchase amount (median of amount × price) for the currently filtered view — `app/InvestmentsTable.tsx`
+- List shows the min and max purchase amount (min/max of amount × price) for the currently filtered view — `app/InvestmentsTable.tsx`
 
 ## Filter
 

--- a/app/InvestmentsTable.tsx
+++ b/app/InvestmentsTable.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { Category, Investment, Label } from '../lib/types';
 import { buildInvestmentsCsv } from '../lib/csv';
+import { minPurchaseAmount, maxPurchaseAmount } from '../lib/purchaseAmount';
 
 interface InvestmentsTableProps {
   investments: Investment[];
@@ -319,6 +320,9 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
     return values.length % 2 === 0 ? (values[mid - 1] + values[mid]) / 2 : values[mid];
   })();
 
+  const minInvested = minPurchaseAmount(filteredInvestments);
+  const maxInvested = maxPurchaseAmount(filteredInvestments);
+
   const hasActiveFilters =
     categoryFilter !== '' ||
     labelFilter !== '' ||
@@ -342,6 +346,8 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
   const totalInvestedLabel = isFiltered ? 'Total invested (filtered)' : 'Total invested';
   const averageLabel = isFiltered ? 'Average (filtered)' : 'Average';
   const medianLabel = isFiltered ? 'Median (filtered)' : 'Median';
+  const minLabel = isFiltered ? 'Min purchase amount (filtered)' : 'Min purchase amount';
+  const maxLabel = isFiltered ? 'Max purchase amount (filtered)' : 'Max purchase amount';
 
   function clearFilters() {
     setCategoryFilter('');
@@ -438,6 +444,12 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
         <p className="mb-4 text-lg font-semibold">
           {medianLabel}: ${medianInvested}
         </p>
+        <p className="mb-4 text-lg font-semibold">
+          {minLabel}: ${minInvested}
+        </p>
+        <p className="mb-4 text-lg font-semibold">
+          {maxLabel}: ${maxInvested}
+        </p>
         <p className="text-center text-gray-500">No investments yet. Add your first one.</p>
       </>
     );
@@ -459,6 +471,12 @@ export function InvestmentsTable({ investments, labels: labelsData }: Investment
       </p>
       <p className="mb-4 text-lg font-semibold">
         {medianLabel}: ${medianInvested}
+      </p>
+      <p className="mb-4 text-lg font-semibold">
+        {minLabel}: ${minInvested}
+      </p>
+      <p className="mb-4 text-lg font-semibold">
+        {maxLabel}: ${maxInvested}
       </p>
       {categoryBreakdown.size > 0 && (
         <section aria-labelledby="total-by-category-heading" className="mb-6">

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -4618,4 +4618,110 @@ describe('HomePage', () => {
       expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
     });
   });
+
+  describe('min/max purchase amount summary', () => {
+    const inv1 = {
+      id: 'r1',
+      instrument: 'AAPL',
+      amount: 10,
+      price: 10,
+      purchaseDate: '2023-01-01',
+      category: 'Stocks',
+      labelIds: [],
+    };
+    const inv2 = {
+      id: 'r2',
+      instrument: 'BTC',
+      amount: 20,
+      price: 10,
+      purchaseDate: '2023-01-02',
+      category: 'Crypto',
+      labelIds: [],
+    };
+    const inv3 = {
+      id: 'r3',
+      instrument: 'US10Y',
+      amount: 30,
+      price: 10,
+      purchaseDate: '2023-01-03',
+      category: 'Bonds',
+      labelIds: [],
+    };
+
+    it('AC-001: shows the smallest and largest amount * price across all investments when no filter is active', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [inv1, inv2, inv3],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      expect(screen.getByText('Min purchase amount: $100')).toBeInTheDocument();
+      expect(screen.getByText('Max purchase amount: $300')).toBeInTheDocument();
+    });
+
+    it('AC-002: updates the min and max when a category filter narrows the visible rows', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [inv1, inv2, inv3],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      const select = screen.getByRole('combobox', { name: /filter by category/i });
+      fireEvent.change(select, { target: { value: 'Crypto' } });
+
+      expect(screen.getByText('Min purchase amount (filtered): $200')).toBeInTheDocument();
+      expect(screen.getByText('Max purchase amount (filtered): $200')).toBeInTheDocument();
+    });
+
+    it('AC-002: updates the min and max when the search box narrows the visible rows', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [inv1, inv2, inv3],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      const search = screen.getByLabelText(/search by name/i);
+      fireEvent.change(search, { target: { value: 'US10Y' } });
+
+      expect(screen.getByText('Min purchase amount (filtered): $300')).toBeInTheDocument();
+      expect(screen.getByText('Max purchase amount (filtered): $300')).toBeInTheDocument();
+    });
+
+    it('AC-003: shows "$0" without "NaN" when the active filter matches zero investments', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [inv1, inv2, inv3],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      const search = screen.getByLabelText(/search by name/i);
+      fireEvent.change(search, { target: { value: 'no-such-instrument' } });
+
+      expect(screen.getByText('Min purchase amount (filtered): $0')).toBeInTheDocument();
+      expect(screen.getByText('Max purchase amount (filtered): $0')).toBeInTheDocument();
+      expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+    });
+
+    it('shows "$0" when there are no investments at all', async () => {
+      (storage.readAll as unknown as vi.Mock).mockResolvedValue({
+        investments: [],
+        labels: [],
+      });
+
+      const Resolved = await HomePage();
+      render(Resolved);
+
+      expect(screen.getByText('Min purchase amount: $0')).toBeInTheDocument();
+      expect(screen.getByText('Max purchase amount: $0')).toBeInTheDocument();
+      expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/lib/purchaseAmount.test.ts
+++ b/lib/purchaseAmount.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { minPurchaseAmount, maxPurchaseAmount } from './purchaseAmount';
+import type { Investment } from './types';
+
+function makeInvestment(amount: number, price: number): Investment {
+  return {
+    id: 'i',
+    instrument: 'X',
+    amount,
+    price,
+    purchaseDate: '2023-01-01',
+    category: 'Stocks',
+    labelIds: [],
+    labels: [],
+  };
+}
+
+describe('minPurchaseAmount', () => {
+  it('returns the smallest amount * price value', () => {
+    const investments = [
+      makeInvestment(10, 5),
+      makeInvestment(2, 100),
+      makeInvestment(7, 3),
+    ];
+
+    expect(minPurchaseAmount(investments)).toBe(21);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(minPurchaseAmount([])).toBe(0);
+  });
+
+  it('returns the single purchase amount when only one investment is given', () => {
+    expect(minPurchaseAmount([makeInvestment(4, 25)])).toBe(100);
+  });
+
+  it('returns the tied value once when two entries share the smallest amount', () => {
+    const investments = [
+      makeInvestment(5, 10),
+      makeInvestment(5, 10),
+      makeInvestment(8, 10),
+    ];
+
+    expect(minPurchaseAmount(investments)).toBe(50);
+  });
+});
+
+describe('maxPurchaseAmount', () => {
+  it('returns the largest amount * price value', () => {
+    const investments = [
+      makeInvestment(10, 5),
+      makeInvestment(2, 100),
+      makeInvestment(7, 3),
+    ];
+
+    expect(maxPurchaseAmount(investments)).toBe(200);
+  });
+
+  it('returns 0 for an empty list', () => {
+    expect(maxPurchaseAmount([])).toBe(0);
+  });
+
+  it('returns the single purchase amount when only one investment is given', () => {
+    expect(maxPurchaseAmount([makeInvestment(4, 25)])).toBe(100);
+  });
+
+  it('returns the tied value once when two entries share the largest amount', () => {
+    const investments = [
+      makeInvestment(5, 10),
+      makeInvestment(10, 10),
+      makeInvestment(10, 10),
+    ];
+
+    expect(maxPurchaseAmount(investments)).toBe(100);
+  });
+});

--- a/lib/purchaseAmount.ts
+++ b/lib/purchaseAmount.ts
@@ -1,0 +1,17 @@
+import type { Investment } from './types';
+
+export function minPurchaseAmount(investments: Investment[]): number {
+  if (investments.length === 0) return 0;
+  return investments.reduce((min, inv) => {
+    const value = inv.amount * inv.price;
+    return value < min ? value : min;
+  }, Infinity);
+}
+
+export function maxPurchaseAmount(investments: Investment[]): number {
+  if (investments.length === 0) return 0;
+  return investments.reduce((max, inv) => {
+    const value = inv.amount * inv.price;
+    return value > max ? value : max;
+  }, -Infinity);
+}


### PR DESCRIPTION
Closes #94

## feat: Users can see min and max purchase amount in the filtered summary

### Changes
```
FEATURES.md                |   1 +
 app/InvestmentsTable.tsx   |  18 ++++++++
 app/page.test.tsx          | 106 +++++++++++++++++++++++++++++++++++++++++++++
 lib/purchaseAmount.test.ts |  76 ++++++++++++++++++++++++++++++++
 lib/purchaseAmount.ts      |  17 ++++++++
 5 files changed, 218 insertions(+)
```

---
*Implemented by Developer Agent.*