### PR TITLE
chore: chore: Add db:reset npm script that resets local Supabase to a known seeded state

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start",
     "db:start": "supabase start",
-    "db:stop": "supabase stop"
+    "db:stop": "supabase stop",
+    "db:reset": "supabase db reset"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,46 @@
+-- Deterministic seed for local development.
+-- Loaded automatically by `supabase db reset` (see [db.seed] in supabase/config.toml).
+-- Money columns are NUMERIC literals — never floats — per VISION.md.
+
+insert into public.users (id, email)
+values ('00000000-0000-0000-0000-000000000001', 'dev@my-investments.local')
+on conflict (id) do nothing;
+
+insert into public.labels (id, name, color, user_id)
+values
+  ('11111111-1111-1111-1111-111111111111', 'long-term', '#3366CC', '00000000-0000-0000-0000-000000000001'),
+  ('22222222-2222-2222-2222-222222222222', 'high-risk', '#CC3333', '00000000-0000-0000-0000-000000000001')
+on conflict (id) do nothing;
+
+insert into public.investments (
+  id, instrument, amount, price, category, purchase_date, notes, user_id
+)
+values
+  (
+    '33333333-3333-3333-3333-333333333333',
+    'AAPL',
+    10.00000000,
+    150.0000,
+    'Stocks',
+    '2026-01-15',
+    'Seed: long-term equity position',
+    '00000000-0000-0000-0000-000000000001'
+  ),
+  (
+    '44444444-4444-4444-4444-444444444444',
+    'BTC',
+    0.25000000,
+    30000.0000,
+    'Crypto',
+    '2026-02-20',
+    null,
+    '00000000-0000-0000-0000-000000000001'
+  )
+on conflict (id) do nothing;
+
+insert into public.investment_labels (investment_id, label_id)
+values
+  ('33333333-3333-3333-3333-333333333333', '11111111-1111-1111-1111-111111111111'),
+  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111'),
+  ('44444444-4444-4444-4444-444444444444', '22222222-2222-2222-2222-222222222222')
+on conflict (investment_id, label_id) do nothing;

--- a/supabase/seed.test.ts
+++ b/supabase/seed.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.join(__dirname, '..');
+const PACKAGE_JSON_PATH = path.join(REPO_ROOT, 'package.json');
+const SEED_PATH = path.join(REPO_ROOT, 'supabase', 'seed.sql');
+
+const FORBIDDEN_FLOAT_PATTERNS: ReadonlyArray<{ name: string; re: RegExp }> = [
+  { name: '::float cast', re: /::\s*float\b/i },
+  { name: '::real cast', re: /::\s*real\b/i },
+  { name: '::double precision cast', re: /::\s*double\s+precision\b/i },
+  { name: 'scientific notation literal', re: /\b\d+\.?\d*e[-+]?\d+\b/i },
+];
+
+function readSeed(): string {
+  expect(
+    fs.existsSync(SEED_PATH),
+    `expected seed file at ${SEED_PATH}`,
+  ).toBe(true);
+  return fs.readFileSync(SEED_PATH, 'utf-8');
+}
+
+function countInsertsInto(sql: string, table: string): number {
+  const re = new RegExp(
+    `insert\\s+into\\s+(?:public\\.)?${table}\\b`,
+    'gi',
+  );
+  return (sql.match(re) ?? []).length;
+}
+
+describe('db:reset npm script', () => {
+  it('exposes db:reset that runs supabase db reset', () => {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf-8'));
+    expect(pkg.scripts['db:reset']).toBe('supabase db reset');
+  });
+});
+
+describe('supabase/seed.sql', () => {
+  it('inserts at least one row into the investments table', () => {
+    const sql = readSeed();
+    expect(countInsertsInto(sql, 'investments')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('inserts at least one row into the labels table', () => {
+    const sql = readSeed();
+    expect(countInsertsInto(sql, 'labels')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('uses NUMERIC-compatible money literals (no float casts, no scientific notation)', () => {
+    const sql = readSeed();
+    for (const { name, re } of FORBIDDEN_FLOAT_PATTERNS) {
+      expect(sql, `seed must not contain ${name}`).not.toMatch(re);
+    }
+  });
+});


### PR DESCRIPTION
Closes #121

## chore: Add db:reset npm script that resets local Supabase to a known seeded state

### Changes
```
package.json          |  3 ++-
 supabase/seed.sql     | 46 ++++++++++++++++++++++++++++++++++++++++++
 supabase/seed.test.ts | 56 +++++++++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 104 insertions(+), 1 deletion(-)
```

---
*Implemented by Developer Agent.*