### PR TITLE
feat: feat: Users can sign in with email and password

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -71,6 +71,8 @@ Format: `- <one-line capability from the user's perspective> — \`<primary file
 ## Auth
 
 - Users can sign up with email and password — `app/sign-up/SignUpForm.tsx`
+- Users can sign in with email and password — `app/sign-in/SignInForm.tsx`
+- Visitors can navigate from the sign-up page to the sign-in page via a link — `app/sign-up/SignUpForm.tsx`
 
 ## Sort
 

--- a/app/sign-in/SignInForm.test.tsx
+++ b/app/sign-in/SignInForm.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SignInForm } from './SignInForm';
+
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    refresh: refreshMock,
+  }),
+}));
+
+describe('SignInForm', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    refreshMock.mockClear();
+  });
+
+  it('renders email and password inputs and a Sign in button', () => {
+    const signIn = vi.fn();
+    render(<SignInForm signIn={signIn} />);
+
+    const email = screen.getByLabelText(/email/i) as HTMLInputElement;
+    expect(email).toBeInTheDocument();
+    expect(email.type).toBe('email');
+    expect(email).toBeRequired();
+
+    const password = screen.getByLabelText(/password/i) as HTMLInputElement;
+    expect(password).toBeInTheDocument();
+    expect(password.type).toBe('password');
+    expect(password).toBeRequired();
+
+    const button = screen.getByRole('button', { name: /sign in/i }) as HTMLButtonElement;
+    expect(button).toBeInTheDocument();
+    expect(button.type).toBe('submit');
+  });
+
+  it('calls signIn once with the entered email and password and redirects to / on success', async () => {
+    const signIn = vi.fn().mockResolvedValue(undefined);
+    render(<SignInForm signIn={signIn} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'alice@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'correcthorse' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(signIn).toHaveBeenCalledTimes(1);
+    });
+
+    expect(signIn).toHaveBeenCalledWith({
+      email: 'alice@example.com',
+      password: 'correcthorse',
+    });
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('does not call signIn and shows an inline error when the email is not a valid format', async () => {
+    const signIn = vi.fn();
+    render(<SignInForm signIn={signIn} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'not-an-email' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'correcthorse' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/invalid/i);
+    expect(signIn).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call signIn and shows an inline error when the password is empty', async () => {
+    const signIn = vi.fn();
+    render(<SignInForm signIn={signIn} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'alice@example.com' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(signIn).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the supabase error inline and stays on the page when signIn rejects', async () => {
+    const signIn = vi.fn().mockRejectedValue(new Error('Invalid login credentials'));
+    render(<SignInForm signIn={signIn} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'alice@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'wrongpassword' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/invalid login credentials/i);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/sign-in/SignInForm.tsx
+++ b/app/sign-in/SignInForm.tsx
@@ -6,25 +6,25 @@ import { useRouter } from 'next/navigation';
 import { z } from 'zod';
 import { supabase } from '../../lib/supabase';
 
-const signUpSchema = z.object({
+const signInSchema = z.object({
   email: z.string().email('Invalid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
+  password: z.string().min(1, 'Password is required'),
 });
 
-export type SignUpFn = (params: { email: string; password: string }) => Promise<void>;
+export type SignInFn = (params: { email: string; password: string }) => Promise<void>;
 
-const defaultSignUp: SignUpFn = async ({ email, password }) => {
-  const { error } = await supabase.auth.signUp({ email, password });
+const defaultSignIn: SignInFn = async ({ email, password }) => {
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
   if (error) {
     throw new Error(error.message);
   }
 };
 
-interface SignUpFormProps {
-  signUp?: SignUpFn;
+interface SignInFormProps {
+  signIn?: SignInFn;
 }
 
-export function SignUpForm({ signUp = defaultSignUp }: SignUpFormProps) {
+export function SignInForm({ signIn = defaultSignIn }: SignInFormProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -34,7 +34,7 @@ export function SignUpForm({ signUp = defaultSignUp }: SignUpFormProps) {
     setError(null);
 
     const formData = new FormData(event.currentTarget);
-    const parsed = signUpSchema.safeParse({
+    const parsed = signInSchema.safeParse({
       email: String(formData.get('email') ?? ''),
       password: String(formData.get('password') ?? ''),
     });
@@ -46,9 +46,9 @@ export function SignUpForm({ signUp = defaultSignUp }: SignUpFormProps) {
 
     startTransition(async () => {
       try {
-        await signUp(parsed.data);
+        await signIn(parsed.data);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Could not sign up, try again');
+        setError(err instanceof Error ? err.message : 'Could not sign in, try again');
         return;
       }
 
@@ -87,7 +87,6 @@ export function SignUpForm({ signUp = defaultSignUp }: SignUpFormProps) {
           name="password"
           type="password"
           required
-          minLength={8}
           className="w-full border border-gray-300 rounded px-3 py-2"
         />
       </div>
@@ -97,13 +96,13 @@ export function SignUpForm({ signUp = defaultSignUp }: SignUpFormProps) {
         disabled={isPending}
         className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white font-semibold px-4 py-2 rounded"
       >
-        {isPending ? 'Signing up…' : 'Sign up'}
+        {isPending ? 'Signing in…' : 'Sign in'}
       </button>
 
       <p className="text-sm text-gray-600">
-        Already have an account?{' '}
-        <Link href="/sign-in" className="text-blue-600 hover:underline">
-          Sign in
+        Don&apos;t have an account?{' '}
+        <Link href="/sign-up" className="text-blue-600 hover:underline">
+          Sign up
         </Link>
       </p>
     </form>

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,0 +1,10 @@
+import { SignInForm } from './SignInForm';
+
+export default function SignInPage() {
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">Sign in</h1>
+      <SignInForm />
+    </main>
+  );
+}

--- a/app/sign-up/SignUpForm.test.tsx
+++ b/app/sign-up/SignUpForm.test.tsx
@@ -38,6 +38,14 @@ describe('SignUpForm', () => {
     expect(button.type).toBe('submit');
   });
 
+  it('renders a link to /sign-in for users who already have an account', () => {
+    render(<SignUpForm signUp={vi.fn()} />);
+
+    const link = screen.getByRole('link', { name: /sign in/i }) as HTMLAnchorElement;
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe('/sign-in');
+  });
+
   it('calls signUp once with the entered email and password and redirects to / on success', async () => {
     const signUp = vi.fn().mockResolvedValue(undefined);
     render(<SignUpForm signUp={signUp} />);


### PR DESCRIPTION
Closes #134

## feat: Users can sign in with email and password

### Changes
```
FEATURES.md                     |   2 +
 app/sign-in/SignInForm.test.tsx | 120 ++++++++++++++++++++++++++++++++++++++++
 app/sign-in/SignInForm.tsx      | 110 ++++++++++++++++++++++++++++++++++++
 app/sign-in/page.tsx            |  10 ++++
 app/sign-up/SignUpForm.test.tsx |   8 +++
 app/sign-up/SignUpForm.tsx      |   8 +++
 6 files changed, 258 insertions(+)
```

---
*Implemented by Developer Agent.*