### PR TITLE
fix: Production build fails with ZodError prerendering /

### DIFF
--- a/lib/investments/storage.test.ts
+++ b/lib/investments/storage.test.ts
@@ -115,8 +115,8 @@ function dbRow(overrides: Partial<Row> = {}): Row {
   return {
     id: 'inv-1',
     instrument: 'AAPL',
-    amount: '10',
-    price: '150',
+    amount: 10,
+    price: 150,
     category: 'Stocks',
     purchase_date: '2026-01-15',
     notes: null,
@@ -155,12 +155,20 @@ describe('lib/investments/storage', () => {
       expect(btc?.labelIds).toEqual([]);
     });
 
-    it('parses NUMERIC strings back into numbers without drift on round-trip', async () => {
-      db.investments.push(dbRow({ id: 'inv-1', amount: '0.1', price: '0.2' }));
+    it('parses NUMERIC values returned as JSON numbers (real PostgREST shape)', async () => {
+      db.investments.push(dbRow({ id: 'inv-1', amount: 0.25, price: 30000 }));
 
       const [investment] = await listInvestments(client);
-      expect(investment.amount).toBe(0.1);
-      expect(investment.price).toBe(0.2);
+      expect(investment.amount).toBe(0.25);
+      expect(investment.price).toBe(30000);
+    });
+
+    it('parses integer NUMERIC values, including zero price', async () => {
+      db.investments.push(dbRow({ id: 'inv-1', amount: 10, price: 0 }));
+
+      const [investment] = await listInvestments(client);
+      expect(investment.amount).toBe(10);
+      expect(investment.price).toBe(0);
     });
 
     it('omits notes when the column is null', async () => {
@@ -221,8 +229,8 @@ describe('lib/investments/storage', () => {
 
       expect(created.id).toBe('inv-1');
       expect(db.investments).toHaveLength(1);
-      expect(db.investments[0].amount).toBe('10');
-      expect(db.investments[0].price).toBe('150');
+      expect(db.investments[0].amount).toBe(10);
+      expect(db.investments[0].price).toBe(150);
     });
 
     it('inserts join rows for every labelId', async () => {
@@ -296,13 +304,15 @@ describe('lib/investments/storage', () => {
 
       expect(created.amount).toBe(0.1);
       expect(created.price).toBe(0.2);
+      expect(db.investments[0].amount).toBe(0.1);
+      expect(db.investments[0].price).toBe(0.2);
     });
   });
 
   describe('updateInvestment', () => {
     beforeEach(() => {
       db.investments.push(
-        dbRow({ id: 'inv-1', instrument: 'AAPL', amount: '10', price: '150' }),
+        dbRow({ id: 'inv-1', instrument: 'AAPL', amount: 10, price: 150 }),
       );
       db.investment_labels.push({ investment_id: 'inv-1', label_id: 'lbl-old' });
     });
@@ -316,8 +326,8 @@ describe('lib/investments/storage', () => {
 
       expect(updated?.price).toBe(200);
       expect(updated?.instrument).toBe('AAPL');
-      expect(db.investments[0].price).toBe('200');
-      expect(db.investments[0].amount).toBe('10');
+      expect(db.investments[0].price).toBe(200);
+      expect(db.investments[0].amount).toBe(10);
     });
 
     it('replaces the labelIds set when provided', async () => {

--- a/lib/investments/storage.ts
+++ b/lib/investments/storage.ts
@@ -6,8 +6,8 @@ import { CATEGORIES, type Investment } from '../types';
 const dbRowSchema = z.object({
   id: z.string(),
   instrument: z.string(),
-  amount: z.string().transform((value) => Number(value)),
-  price: z.string().transform((value) => Number(value)),
+  amount: z.number(),
+  price: z.number(),
   category: z.enum(CATEGORIES),
   purchase_date: z.string(),
   notes: z.string().nullable(),
@@ -40,10 +40,6 @@ function rowToInvestment(row: DbInvestmentRow): Investment {
     investment.notes = row.notes;
   }
   return investment;
-}
-
-function moneyToString(value: number): string {
-  return value.toString();
 }
 
 export async function listInvestments(
@@ -88,8 +84,8 @@ export async function createInvestment(
   const insertRow = {
     id: investment.id,
     instrument: investment.instrument,
-    amount: moneyToString(investment.amount),
-    price: moneyToString(investment.price),
+    amount: investment.amount,
+    price: investment.price,
     purchase_date: investment.purchaseDate,
     category: investment.category,
     notes: investment.notes ?? null,
@@ -138,10 +134,10 @@ export async function updateInvestment(
     columnUpdate.instrument = patch.instrument;
   }
   if (patch.amount !== undefined) {
-    columnUpdate.amount = moneyToString(patch.amount);
+    columnUpdate.amount = patch.amount;
   }
   if (patch.price !== undefined) {
-    columnUpdate.price = moneyToString(patch.price);
+    columnUpdate.price = patch.price;
   }
   if (patch.purchaseDate !== undefined) {
     columnUpdate.purchase_date = patch.purchaseDate;


### PR DESCRIPTION
Closes #141

## fix: production build fails with ZodError prerendering /

### Root cause

`dbRowSchema` in `lib/investments/storage.ts` declared `amount` and `price` as `z.string().transform(Number)`, but PostgREST returns `NUMERIC` columns as JSON numbers. Unit tests mocked strings (matching the buggy assumption), so the bug only surfaced at prerender time when real Supabase data was hit.

### Changes

`lib/investments/storage.ts`
- `amount` and `price` schema fields → `z.number()` (real PostgREST shape).
- Removed `moneyToString` since PostgREST accepts numbers directly for NUMERIC writes.

`lib/investments/storage.test.ts`
- `dbRow` factory and per-test overrides now use numeric mock values, reflecting the real PostgREST contract per AGENTS.md "Mocks vs. real boundaries".
- Replaced misleading "parses NUMERIC strings" round-trip test with two AC-aligned tests: `0.25`/`30000` and integer `10`/`0` (zero price).

### AC-001 — `npm run build` evidence

```
   ▲ Next.js 15.5.15
   - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully in 3.0s
   Linting and checking validity of types ...
   Collecting page data ...
 ✓ Generating static pages (8/8)

Route (app)                                 Size  First Load JS
┌ ○ /                                    5.57 kB         169 kB
```

`/` prerendered as static with no ZodError — the original failure mode is gone.

### AC-002 — local Supabase smoke test evidence

1. `npm run db:start` + `npm run db:reset` → migrations + seed applied cleanly.
2. PostgREST raw response confirming the original bug shape (NUMERIC returned as JSON `number`, not string):

   ```
   GET /rest/v1/investments?select=id,instrument,amount,price&limit=2
   [{"id":"33333333-...","instrument":"AAPL","amount":10.00000000,"price":150.0000},
    {"id":"44444444-...","instrument":"BTC","amount":0.25000000,"price":30000.0000}]
   ```

3. `npm run dev` + `curl http://localhost:3000/` → `HTTP 200`, both seed rows (`AAPL`, `BTC`) present in the rendered HTML, no runtime error in dev log (`GET / 200 in 3712ms`).

### AC-003 — unit tests

```
 Test Files  17 passed (17)
      Tests  334 passed (334)
```

---

*Smoke evidence injected manually after Reviewer requested it on rule 11. Tracked as system debt: rework cycle should be able to update PR descriptions.*